### PR TITLE
Update README.md about percent encoding DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ protocol://username:password@host:port/database_name?options
 ```
 
 - `protocol` must be one of `mysql`, `postgres`, `postgresql`, `sqlite`, `sqlite3`, `clickhouse`
+- `password` must be URL encoded (you will get an error if you have special charactors in your password)
 - `host` can be either a hostname or IP address
 - `options` are driver-specific (refer to the underlying Go SQL drivers if you wish to use these)
 


### PR DESCRIPTION
Passwords with special characters must be URL encoded (percent encoded) when using the DATABASE_URL variable. Otherwise an error might pop up from net/url package when parsing. So it is probably better to mention that in the documentation.